### PR TITLE
fix: Using capacitor plugin with MABS 12 builds

### DIFF
--- a/packages/outsystems-wrapper/src/index.ts
+++ b/packages/outsystems-wrapper/src/index.ts
@@ -4,10 +4,11 @@ import { v4 as uuidv4 } from 'uuid'
 class OSGeolocation {
     #lastPosition: Position | null = null
     #timers: { [key: string]: ReturnType<typeof setTimeout> | undefined } = {}
+    #callbackIdsMap: { [watchId: string]: string } = {}
 
     getCurrentPosition(success: (position: Position) => void, error: (err: PluginError | GeolocationPositionError) => void, options: CurrentPositionOptions): void {
         // @ts-ignore
-        if (typeof (CapacitorUtils) === 'undefined') {
+        if (typeof (CapacitorUtils) === 'undefined' && !this.#isCapacitorPluginDefined()) {
             // if we're not in synapse land, we call the good old bridge or web api 
             // (it's the same clobber)
             navigator.geolocation.getCurrentPosition(success, error, options)
@@ -61,13 +62,23 @@ class OSGeolocation {
             }
 
             // @ts-ignore
-            CapacitorUtils.Synapse.Geolocation.getCurrentPosition(options, successCallback, errorCallback)
+            if (typeof (CapacitorUtils) === "undefined") {
+                // if synapse is not available, we call the Capacitor plugin directly
+                // currently Synapse doesn't work in MABS 12 builds, so we need to call the Capacitor plugin directly in this case
+                // @ts-ignore
+                Capacitor.Plugins.Geolocation.getCurrentPosition(options)
+                    .then(successCallback)
+                    .catch(errorCallback);
+            } else {
+                // @ts-ignore
+                CapacitorUtils.Synapse.Geolocation.getCurrentPosition(options, successCallback, errorCallback)
+            }
         }
     }
 
     watchPosition(success: (result: Position) => void, error: (error: PluginError | GeolocationPositionError) => void, options: WatchPositionOptions): string | number {
         // @ts-ignore
-        if (typeof (CapacitorUtils) === 'undefined') {
+        if (typeof (CapacitorUtils) === 'undefined' && !this.#isCapacitorPluginDefined()) {
             // if we're not in synapse land, we call the good old bridge or web api 
             // (it's the same clobber)
             return navigator.geolocation.watchPosition(success, error, options)
@@ -107,9 +118,29 @@ class OSGeolocation {
         }
         options.id = watchId
 
-        // @ts-ignore
-        CapacitorUtils.Synapse.Geolocation.watchPosition(options, successCallback, errorCallback)
-        return watchId
+        if (this.#isCapacitorPluginDefined()) {
+            // if synapse is not available, we call the Capacitor plugin directly
+            // currently Synapse doesn't work in MABS 12 builds, so we need to call the Capacitor plugin directly in this case
+            // Moreover, for the case of watch location, capacitor returns a callback id that should be stored on the wrapper to make sure watches are cleared properly
+            //  So in other words, Synapse can't be used in watchPosition.
+            // @ts-ignore
+            let callbackId: string = Capacitor.Plugins.Geolocation.watchPosition(
+                options, 
+                (position: Position | OSGLOCPosition, err?: any) => {
+                    if (err) {
+                        errorCallback(err);
+                    }
+                    else if (position) {
+                        successCallback(position)
+                    }
+                }
+            );
+            this.#callbackIdsMap[watchId] = callbackId;
+        } else {
+            // @ts-ignore
+            CapacitorUtils.Synapse.Geolocation.watchPosition(options, successCallback, errorCallback);
+        }
+        return watchId;
     }
 
     /**
@@ -117,7 +148,7 @@ class OSGeolocation {
     */
     clearWatch(options: ClearWatchOptions, success: () => void = () => { }, error: (error: PluginError | GeolocationPositionError) => void = () => { }): void {
         // @ts-ignore
-        if (typeof (CapacitorUtils) === 'undefined') {
+        if (typeof (CapacitorUtils) === 'undefined' && !this.#isCapacitorPluginDefined()) {
             // if we're not in synapse land, we call the good old bridge or web api 
             // (it's the same clobber)
             // @ts-ignore
@@ -128,8 +159,28 @@ class OSGeolocation {
 
         clearTimeout(this.#timers[options.id])
         delete this.#timers[options.id]
+
+        let optionsWithCorrectId = options;
+        if (this.#callbackIdsMap[options.id] != 'undefined') {
+            // Capacitor uses a different a callback id instead of the watch id generated here in the wrapper
+            optionsWithCorrectId = { id: this.#callbackIdsMap[options.id] }
+        }
+        const successCallback = () => {
+            delete this.#callbackIdsMap[options.id];
+            success()
+        }
         // @ts-ignore
-        CapacitorUtils.Synapse.Geolocation.clearWatch(options, success, error)
+        if (typeof (CapacitorUtils) === "undefined") {
+            // if synapse is not available, we call the Capacitor plugin directly
+            // currently Synapse doesn't work in MABS 12 builds, so we need to call the Capacitor plugin directly in this case
+            // @ts-ignore
+            Capacitor.Plugins.Geolocation.clearWatch(optionsWithCorrectId)
+                .then(successCallback)
+                .catch(error);
+        } else {
+            // @ts-ignore
+            CapacitorUtils.Synapse.Geolocation.clearWatch(optionsWithCorrectId, successCallback, error)
+        }
     }
 
 
@@ -183,6 +234,16 @@ class OSGeolocation {
      */
     #isLegacyPosition(position: Position | OSGLOCPosition): position is OSGLOCPosition {
         return (position as OSGLOCPosition).velocity !== undefined
+    }
+
+    /**
+     * Checks if @capacitor/geolocation plugin is defined
+     * 
+     * @returns true if geolocation capacitor plugin is available; false otherwise
+     */
+    #isCapacitorPluginDefined(): boolean {
+        // @ts-ignore
+        return (typeof(Capacitor) !== "undefined" && typeof(Capacitor.Plugins) !== "undefined" && typeof(Capacitor.Plugins.Geolocation) !== "undefined")
     }
 }
 

--- a/packages/outsystems-wrapper/src/index.ts
+++ b/packages/outsystems-wrapper/src/index.ts
@@ -161,7 +161,7 @@ class OSGeolocation {
         delete this.#timers[options.id]
 
         let optionsWithCorrectId = options;
-        if (this.#callbackIdsMap[options.id] != 'undefined') {
+        if (this.#callbackIdsMap[options.id]) {
             // Capacitor uses a different a callback id instead of the watch id generated here in the wrapper
             optionsWithCorrectId = { id: this.#callbackIdsMap[options.id] }
         }


### PR DESCRIPTION
## Description

Currently, MABS 12 (which uses Capacitor Shell) builds of LocationSampleAppCapacitor (sample app that uses LocationPluginCapacitor Outsystems Plugin on ODC) are not able to use Synapse. Meaning that calls for `CapacitorUtils.Synapse.Geolocation` don't work with the Capacitor plugin on Outsystems.

Moreover, the API for `watchPosition` is slightly different between Cordova and Capacitor, as the latter returns a callback ID.

This PR calls the geolocation APIs using the Capacitor Plugin directly, if it is defined.

Once Synapse is working on MABS 12 builds, we don't need the calls to `Capacitor.Plugins.Geolocation`, except for `watchPosition` (because of the API difference between cordova and capacitor)

## Context

References: https://outsystemsrd.atlassian.net/browse/RMET-4017

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [X] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [ ] iOS
- [X] JavaScript

## Tests

Tested to confirm that the MABS 12 builds with Capacitor Plugin work with the new wrapper, and also tested to see if the current location plugin (using Cordova) also works with this new wrapper.
Tests made on Android, iOS and PWAs.

If you'd like to test as well:

- [Existing Location sample app - ODC](https://eng-mobile.outsystems.dev/apps/distributemobile?appid=9254cba4-9c63-41f2-a72e-552fe7894412&stageid=82798f0c-48de-4787-b0e1-dd3204ce2e6b)
- [New Capacitor Location sample app - ODC](https://eng-mobile.outsystems.dev/apps/distributemobile?appid=74cb4606-368d-4713-9f08-5cd0578f588f&stageid=82798f0c-48de-4787-b0e1-dd3204ce2e6b)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [ ] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
