### PR TITLE
fix: MABS 12 compatibility issues 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### 2025-02-14
+
+- Fix: plugin declaration in `plugin.xml`.
+- Chore: Update Synapse dependency.
+
 ## [1.0.0]
 
 ### 2025-01-10

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,12 @@
 {
-  "name": "root",
+  "name": "com.outsystems.plugins.geolocation",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "root",
+      "name": "com.outsystems.plugins.geolocation",
+      "version": "1.0.0",
       "devDependencies": {
         "@types/node": "^20.14.8",
         "lerna": "^8.1.8",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
-  "name": "root",
+  "name": "com.outsystems.plugins.geolocation",
+  "version": "1.0.0",
   "private": true,
   "dependencies": {},
   "scripts": {

--- a/packages/cordova-plugin/README.md
+++ b/packages/cordova-plugin/README.md
@@ -15,7 +15,6 @@ cordova plugin add <path-to-repo-local-clone>
 * [`getCurrentPosition(...)`](#getcurrentposition)
 * [`watchPosition(...)`](#watchposition)
 * [`clearWatch(...)`](#clearwatch)
-* [Interfaces](#interfaces)
 * [Type Aliases](#type-aliases)
 
 </docgen-index>
@@ -37,6 +36,8 @@ Get the current GPS location of the device
 | **`success`** | <code>(output: <a href="#position">Position</a>) =&gt; void</code>        |
 | **`error`**   | <code>(error: <a href="#pluginerror">PluginError</a>) =&gt; void</code>   |
 
+**Since:** 1.0.0
+
 --------------------
 
 
@@ -55,6 +56,8 @@ can consume a large amount of energy. Be smart about listening only when you nee
 | **`success`** | <code>(output: <a href="#position">Position</a>) =&gt; void</code>      |
 | **`error`**   | <code>(error: <a href="#pluginerror">PluginError</a>) =&gt; void</code> |
 
+**Since:** 1.0.0
+
 --------------------
 
 
@@ -72,26 +75,22 @@ Clear a given watch
 | **`success`** | <code>() =&gt; void</code>                                              |
 | **`error`**   | <code>(error: <a href="#pluginerror">PluginError</a>) =&gt; void</code> |
 
+**Since:** 1.0.0
+
 --------------------
+
 
 ### Type Aliases
 
 
 #### CurrentPositionOptions
 
-<code>{  enableHighAccuracy?: boolean;  timeout?: number; maximumAge?: number; minimumUpdateInterval?: number; }
-</code>
+<code>{ /** * High accuracy mode (such as GPS, if available) * * On Android 12+ devices it will be ignored if users didn't grant * ACCESS_FINE_LOCATION permissions (can be checked with location alias). * * @default false * @since 1.0.0 */ enableHighAccuracy?: boolean; /** * The maximum wait time in milliseconds for location updates. * * In Android, since version 4.0.0 of the plugin, timeout gets ignored for getCurrentPosition. * * @default 10000 * @since 1.0.0 */ timeout?: number; /** * The maximum age in milliseconds of a possible cached position that is acceptable to return * * @default 0 * @since 1.0.0 */ maximumAge?: number; /** * The minumum update interval for location updates. * * If location updates are available faster than this interval then an update * will only occur if the minimum update interval has expired since the last location update. * * This parameter is only available for Android. It has no effect on iOS or Web platforms. * * @default 5000 * @since 6.1.0 */ minimumUpdateInterval?: number; }</code>
+
 
 #### Position
 
-<code>{ timestamp: number; coords: {
-    latitude: number; 
-    longitude: number; 
-    accuracy: number; 
-    altitudeAccuracy: number | null;
-    altitude: number | null;
-     speed: number | null;
-     heading: number | null; }; }</code>
+<code>{ /** * Creation timestamp for coords * * @since 1.0.0 */ timestamp: number; /** * The GPS coordinates along with the accuracy of the data * * @since 1.0.0 */ coords: { /** * Latitude in decimal degrees * * @since 1.0.0 */ latitude: number; /** * longitude in decimal degrees * * @since 1.0.0 */ longitude: number; /** * Accuracy level of the latitude and longitude coordinates in meters * * @since 1.0.0 */ accuracy: number; /** * Accuracy level of the altitude coordinate in meters, if available. * * Available on all iOS versions and on Android 8.0+. * * @since 1.0.0 */ altitudeAccuracy: number | null; /** * The altitude the user is at (if available) * * @since 1.0.0 */ altitude: number | null; /** * The speed the user is traveling (if available) * * @since 1.0.0 */ speed: number | null; /** * The heading the user is facing (if available) * * @since 1.0.0 */ heading: number | null; }; }</code>
 
 
 #### PluginError

--- a/packages/cordova-plugin/dist/plugin.cjs
+++ b/packages/cordova-plugin/dist/plugin.cjs
@@ -42,8 +42,8 @@ function u(t) {
     }
   );
 }
-function y() {
-  window.CapacitorUtils = window.CapacitorUtils || {}, window.Capacitor !== void 0 ? s(window) : window.cordova !== void 0 && u(window);
+function y(t = false) {
+  window.CapacitorUtils = window.CapacitorUtils || {}, window.Capacitor !== void 0 && !t ? s(window) : window.cordova !== void 0 && u(window);
 }
 const CurrentPositionOptionsDefault = {
   enableHighAccuracy: false,
@@ -106,4 +106,4 @@ module.exports = {
   watchPosition,
   clearWatch
 };
-y();
+y(true);

--- a/packages/cordova-plugin/dist/plugin.js
+++ b/packages/cordova-plugin/dist/plugin.js
@@ -44,8 +44,8 @@
       }
     );
   }
-  function y() {
-    window.CapacitorUtils = window.CapacitorUtils || {}, window.Capacitor !== void 0 ? s(window) : window.cordova !== void 0 && u(window);
+  function y(t = false) {
+    window.CapacitorUtils = window.CapacitorUtils || {}, window.Capacitor !== void 0 && !t ? s(window) : window.cordova !== void 0 && u(window);
   }
   const CurrentPositionOptionsDefault = {
     enableHighAccuracy: false,
@@ -108,5 +108,5 @@
     watchPosition,
     clearWatch
   };
-  y();
+  y(true);
 });

--- a/packages/cordova-plugin/dist/plugin.mjs
+++ b/packages/cordova-plugin/dist/plugin.mjs
@@ -41,8 +41,8 @@ function u(t) {
     }
   );
 }
-function y() {
-  window.CapacitorUtils = window.CapacitorUtils || {}, window.Capacitor !== void 0 ? s(window) : window.cordova !== void 0 && u(window);
+function y(t = false) {
+  window.CapacitorUtils = window.CapacitorUtils || {}, window.Capacitor !== void 0 && !t ? s(window) : window.cordova !== void 0 && u(window);
 }
 const CurrentPositionOptionsDefault = {
   enableHighAccuracy: false,
@@ -105,4 +105,4 @@ module.exports = {
   watchPosition,
   clearWatch
 };
-y();
+y(true);

--- a/packages/cordova-plugin/package.json
+++ b/packages/cordova-plugin/package.json
@@ -25,7 +25,7 @@
   "author": "OutSystems",
   "license": "MIT",
   "dependencies": {
-    "@capacitor/synapse": "^1.0.1"
+    "@capacitor/synapse": "1.0.2-dev.1"
   },
   "eslintConfig": {
     "extends": "@ionic/eslint-config/recommended"

--- a/packages/cordova-plugin/package.json
+++ b/packages/cordova-plugin/package.json
@@ -25,7 +25,7 @@
   "author": "OutSystems",
   "license": "MIT",
   "dependencies": {
-    "@capacitor/synapse": "1.0.2-dev.1"
+    "@capacitor/synapse": "^1.0.2"
   },
   "eslintConfig": {
     "extends": "@ionic/eslint-config/recommended"

--- a/packages/cordova-plugin/src/index.ts
+++ b/packages/cordova-plugin/src/index.ts
@@ -1,6 +1,7 @@
 import { exposeSynapse } from '@capacitor/synapse';
 
-exposeSynapse();
+// true -> to make sure Synapse uses this cordova plugin for capacitor builds.
+exposeSynapse(true);
 
 export * from './web';
 export * from './definitions';

--- a/packages/outsystems-wrapper/src/index.ts
+++ b/packages/outsystems-wrapper/src/index.ts
@@ -7,9 +7,8 @@ class OSGeolocation {
     #callbackIdsMap: { [watchId: string]: string } = {}
 
     getCurrentPosition(success: (position: Position) => void, error: (err: PluginError | GeolocationPositionError) => void, options: CurrentPositionOptions): void {
-        // @ts-ignore
-        if (typeof (CapacitorUtils) === 'undefined' && !this.#isCapacitorPluginDefined()) {
-            // if we're not in synapse land, we call the good old bridge or web api 
+        if (this.#shouldUseWebApi()) {
+            // if we're not in a native mobile app, we call the good old bridge or web api 
             // (it's the same clobber)
             navigator.geolocation.getCurrentPosition(success, error, options)
             return
@@ -61,25 +60,24 @@ class OSGeolocation {
                 this.#timers[id] = timeoutID
             }
 
-            // @ts-ignore
-            if (typeof (CapacitorUtils) === "undefined") {
-                // if synapse is not available, we call the Capacitor plugin directly
-                // currently Synapse doesn't work in MABS 12 builds, so we need to call the Capacitor plugin directly in this case
+            if (this.#isSynapseDefined()) {
+                // @ts-ignore
+                CapacitorUtils.Synapse.Geolocation.getCurrentPosition(options, successCallback, errorCallback)
+            } else {
+                // currently Synapse doesn't work in MABS 12 builds with Capacitor npm package
+                //  But it works with cordova via Github repository
+                //  So we need to call the Capacitor plugin directly
                 // @ts-ignore
                 Capacitor.Plugins.Geolocation.getCurrentPosition(options)
                     .then(successCallback)
                     .catch(errorCallback);
-            } else {
-                // @ts-ignore
-                CapacitorUtils.Synapse.Geolocation.getCurrentPosition(options, successCallback, errorCallback)
             }
         }
     }
 
     watchPosition(success: (result: Position) => void, error: (error: PluginError | GeolocationPositionError) => void, options: WatchPositionOptions): string | number {
-        // @ts-ignore
-        if (typeof (CapacitorUtils) === 'undefined' && !this.#isCapacitorPluginDefined()) {
-            // if we're not in synapse land, we call the good old bridge or web api 
+        if (this.#shouldUseWebApi()) {
+            // if we're not in a native mobile app, we call the good old bridge or web api 
             // (it's the same clobber)
             return navigator.geolocation.watchPosition(success, error, options)
         }
@@ -119,10 +117,8 @@ class OSGeolocation {
         options.id = watchId
 
         if (this.#isCapacitorPluginDefined()) {
-            // if synapse is not available, we call the Capacitor plugin directly
-            // currently Synapse doesn't work in MABS 12 builds, so we need to call the Capacitor plugin directly in this case
-            // Moreover, for the case of watch location, capacitor returns a callback id that should be stored on the wrapper to make sure watches are cleared properly
-            //  So in other words, Synapse can't be used in watchPosition.
+            // For the case of watch location, capacitor returns a callback id that should be stored on the wrapper to make sure watches are cleared properly
+            //  So in other words, Synapse can't be used in watchPosition for Capacitor.
             // @ts-ignore
             let callbackId: string = Capacitor.Plugins.Geolocation.watchPosition(
                 options, 
@@ -138,7 +134,7 @@ class OSGeolocation {
             this.#callbackIdsMap[watchId] = callbackId;
         } else {
             // @ts-ignore
-            CapacitorUtils.Synapse.Geolocation.watchPosition(options, successCallback, errorCallback);
+            cordova.plugins.Geolocation.watchPosition(options, successCallback, errorCallback)
         }
         return watchId;
     }
@@ -147,10 +143,8 @@ class OSGeolocation {
     * Clears the specified heading watch.
     */
     clearWatch(options: ClearWatchOptions, success: () => void = () => { }, error: (error: PluginError | GeolocationPositionError) => void = () => { }): void {
-        // @ts-ignore
-        if (typeof (CapacitorUtils) === 'undefined' && !this.#isCapacitorPluginDefined()) {
-            // if we're not in synapse land, we call the good old bridge or web api 
-            // (it's the same clobber)
+        if (this.#shouldUseWebApi()) {
+            // if we're not in a native mobile app, we call the good old bridge or web api 
             // @ts-ignore
             navigator.geolocation.clearWatch(options.id)
             success()
@@ -169,17 +163,17 @@ class OSGeolocation {
             delete this.#callbackIdsMap[options.id];
             success()
         }
-        // @ts-ignore
-        if (typeof (CapacitorUtils) === "undefined") {
-            // if synapse is not available, we call the Capacitor plugin directly
-            // currently Synapse doesn't work in MABS 12 builds, so we need to call the Capacitor plugin directly in this case
+        if (this.#isSynapseDefined()) {
+            // @ts-ignore
+            CapacitorUtils.Synapse.Geolocation.clearWatch(optionsWithCorrectId, successCallback, error)
+        } else {
+            // currently Synapse doesn't work in MABS 12 builds with Capacitor npm package
+            //  But it works with cordova via Github repository
+            //  So we need to call the Capacitor plugin directly
             // @ts-ignore
             Capacitor.Plugins.Geolocation.clearWatch(optionsWithCorrectId)
                 .then(successCallback)
                 .catch(error);
-        } else {
-            // @ts-ignore
-            CapacitorUtils.Synapse.Geolocation.clearWatch(optionsWithCorrectId, successCallback, error)
         }
     }
 
@@ -237,6 +231,25 @@ class OSGeolocation {
     }
 
     /**
+     * @returns true if should use web API, false otherwise
+     */
+    #shouldUseWebApi(): boolean {
+        // @ts-ignore
+        if (this.#isSynapseDefined()) {
+            // synapse is defined, which means the app is a native mobile app (PWAs don't need synapse)
+            return false
+        }
+        // TODO once synapse dependency is correctly installed in MABS 12
+        //  we can remove the if specific to capacitor here
+        if (this.#isCapacitorPluginDefined()) {
+            // @ts-ignore
+            const platform = Capacitor.getPlatform() 
+            return platform === "web"
+        }
+        return true
+    }
+
+    /**
      * Checks if @capacitor/geolocation plugin is defined
      * 
      * @returns true if geolocation capacitor plugin is available; false otherwise
@@ -244,6 +257,14 @@ class OSGeolocation {
     #isCapacitorPluginDefined(): boolean {
         // @ts-ignore
         return (typeof(Capacitor) !== "undefined" && typeof(Capacitor.Plugins) !== "undefined" && typeof(Capacitor.Plugins.Geolocation) !== "undefined")
+    }
+
+    /**
+     * @returns true if synapse is defined, false otherwise
+     */
+    #isSynapseDefined(): boolean {
+        // @ts-ignore
+        return typeof (CapacitorUtils) !== "undefined"
     }
 }
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget id="com.outsystems.plugins.geolocation" version="1.0.0" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="com.outsystems.plugins.geolocation" version="1.0.0" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>OSGeolocationPlugin</name>
     <description>OutSystems' cordova geolocation plugin</description>
     <author>OutSystems Inc</author>
@@ -54,4 +54,4 @@
             </pods>
         </podspec>
     </platform>
-</widget>
+</plugin>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
   packages/cordova-plugin:
     dependencies:
       '@capacitor/synapse':
-        specifier: 1.0.2-dev.1
-        version: 1.0.2-dev.1
+        specifier: ^1.0.2
+        version: 1.0.2
     devDependencies:
       '@capacitor/docgen':
         specifier: ^0.2.2
@@ -142,8 +142,8 @@ packages:
     engines: {node: '>=14.5.0'}
     hasBin: true
 
-  '@capacitor/synapse@1.0.2-dev.1':
-    resolution: {integrity: sha512-8LRjx5DdpEfZvxDNvlUxValTLuhnTK+VwlYon8l++5+1jMK5rjDmlt2YoA5lgNpbwXcugS8tDQdDEGkBBJ6DDw==}
+  '@capacitor/synapse@1.0.2':
+    resolution: {integrity: sha512-ynq39s4D2rhk+aVLWKfKfMCz9SHPKijL9tq8aFL5dG7ik7/+PvBHmg9cPHbqdvFEUSMmaGzL6cIjzkOruW7vGA==}
 
   '@emnapi/core@1.3.1':
     resolution: {integrity: sha512-pVGjBIt1Y6gg3EJN8jTcfpP/+uuRksIo055oE/OBkDNcjZqVbfkWCksG1Jp4yZnj3iKWyWX8fdG/j6UDYPbFog==}
@@ -3333,7 +3333,7 @@ snapshots:
       minimist: 1.2.8
       typescript: 4.2.4
 
-  '@capacitor/synapse@1.0.2-dev.1': {}
+  '@capacitor/synapse@1.0.2': {}
 
   '@emnapi/core@1.3.1':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
         version: 20.17.12
       lerna:
         specifier: ^8.1.8
-        version: 8.1.9
+        version: 8.1.9(encoding@0.1.13)
       typescript:
         specifier: ~5.4.5
         version: 5.4.5
@@ -21,15 +21,15 @@ importers:
   packages/cordova-plugin:
     dependencies:
       '@capacitor/synapse':
-        specifier: ^1.0.1
-        version: 1.0.1
+        specifier: 1.0.2-dev.1
+        version: 1.0.2-dev.1
     devDependencies:
       '@capacitor/docgen':
         specifier: ^0.2.2
         version: 0.2.2
       '@rollup/plugin-typescript':
         specifier: ^11.1.6
-        version: 11.1.6(typescript@5.4.5)
+        version: 11.1.6(rollup@4.30.1)(tslib@2.8.1)(typescript@5.4.5)
       '@types/cordova':
         specifier: ^11.0.3
         version: 11.0.3
@@ -56,13 +56,13 @@ importers:
         version: 5.4.11(@types/node@20.17.12)
       vite-plugin-dts:
         specifier: ^3.9.1
-        version: 3.9.1(@types/node@20.17.12)(typescript@5.4.5)(vite@5.4.11)
+        version: 3.9.1(@types/node@20.17.12)(rollup@4.30.1)(typescript@5.4.5)(vite@5.4.11(@types/node@20.17.12))
 
   packages/example-app-cordova:
     devDependencies:
       com.outsystems.cordova.plugins.osgeolocation:
         specifier: file:../cordova-plugin
-        version: com.outsystems.plugins.osgeolocation@file:packages/cordova-plugin
+        version: link:../cordova-plugin
       cordova-android:
         specifier: ^13.0.0
         version: 13.0.0
@@ -78,7 +78,7 @@ importers:
     devDependencies:
       '@rollup/plugin-typescript':
         specifier: ^11.1.6
-        version: 11.1.6(typescript@5.4.5)
+        version: 11.1.6(rollup@4.30.1)(tslib@2.8.1)(typescript@5.4.5)
       '@types/cordova':
         specifier: ^11.0.3
         version: 11.0.3
@@ -105,7 +105,7 @@ importers:
         version: 5.4.11(@types/node@20.17.12)
       vite-plugin-dts:
         specifier: ^4.4.0
-        version: 4.4.0(@types/node@20.17.12)(typescript@5.4.5)(vite@5.4.11)
+        version: 4.4.0(@types/node@20.17.12)(rollup@4.30.1)(typescript@5.4.5)(vite@5.4.11(@types/node@20.17.12))
 
 packages:
 
@@ -142,8 +142,8 @@ packages:
     engines: {node: '>=14.5.0'}
     hasBin: true
 
-  '@capacitor/synapse@1.0.1':
-    resolution: {integrity: sha512-eLSoIccv6dqJ9GQePlQfHizE91tn9+6Ysj9ZWTi4JwV4OX4As6y505CvEYuM99MiLkdpL+Vcx3jNp8AEeQG5VA==}
+  '@capacitor/synapse@1.0.2-dev.1':
+    resolution: {integrity: sha512-8LRjx5DdpEfZvxDNvlUxValTLuhnTK+VwlYon8l++5+1jMK5rjDmlt2YoA5lgNpbwXcugS8tDQdDEGkBBJ6DDw==}
 
   '@emnapi/core@1.3.1':
     resolution: {integrity: sha512-pVGjBIt1Y6gg3EJN8jTcfpP/+uuRksIo055oE/OBkDNcjZqVbfkWCksG1Jp4yZnj3iKWyWX8fdG/j6UDYPbFog==}
@@ -1152,10 +1152,6 @@ packages:
   columnify@1.6.0:
     resolution: {integrity: sha512-lomjuFZKfM6MSAnV9aCZC9sc0qGbmZdfygNv+nCpqVkSKdCxCklLtd16O0EILGkImHw9ZpHkAnHaB+8Zxq5W6Q==}
     engines: {node: '>=8.0.0'}
-
-  com.outsystems.plugins.osgeolocation@file:packages/cordova-plugin:
-    resolution: {directory: packages/cordova-plugin, type: directory}
-    name: com.outsystems.plugins.osgeolocation
 
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
@@ -3337,7 +3333,7 @@ snapshots:
       minimist: 1.2.8
       typescript: 4.2.4
 
-  '@capacitor/synapse@1.0.1': {}
+  '@capacitor/synapse@1.0.2-dev.1': {}
 
   '@emnapi/core@1.3.1':
     dependencies:
@@ -3464,14 +3460,14 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.0': {}
 
-  '@lerna/create@8.1.9(typescript@5.4.5)':
+  '@lerna/create@8.1.9(encoding@0.1.13)(typescript@5.4.5)':
     dependencies:
       '@npmcli/arborist': 7.5.4
       '@npmcli/package-json': 5.2.0
       '@npmcli/run-script': 8.1.0
       '@nx/devkit': 20.3.1(nx@20.3.1)
       '@octokit/plugin-enterprise-rest': 6.0.1
-      '@octokit/rest': 19.0.11
+      '@octokit/rest': 19.0.11(encoding@0.1.13)
       aproba: 2.0.0
       byte-size: 8.1.1
       chalk: 4.1.0
@@ -3504,7 +3500,7 @@ snapshots:
       make-dir: 4.0.0
       minimatch: 3.0.5
       multimatch: 5.0.0
-      node-fetch: 2.6.7
+      node-fetch: 2.6.7(encoding@0.1.13)
       npm-package-arg: 11.0.2
       npm-packlist: 8.0.2
       npm-registry-fetch: 17.1.0
@@ -3815,11 +3811,11 @@ snapshots:
 
   '@octokit/auth-token@3.0.4': {}
 
-  '@octokit/core@4.2.4':
+  '@octokit/core@4.2.4(encoding@0.1.13)':
     dependencies:
       '@octokit/auth-token': 3.0.4
-      '@octokit/graphql': 5.0.6
-      '@octokit/request': 6.2.8
+      '@octokit/graphql': 5.0.6(encoding@0.1.13)
+      '@octokit/request': 6.2.8(encoding@0.1.13)
       '@octokit/request-error': 3.0.3
       '@octokit/types': 9.3.2
       before-after-hook: 2.2.3
@@ -3833,9 +3829,9 @@ snapshots:
       is-plain-object: 5.0.0
       universal-user-agent: 6.0.1
 
-  '@octokit/graphql@5.0.6':
+  '@octokit/graphql@5.0.6(encoding@0.1.13)':
     dependencies:
-      '@octokit/request': 6.2.8
+      '@octokit/request': 6.2.8(encoding@0.1.13)
       '@octokit/types': 9.3.2
       universal-user-agent: 6.0.1
     transitivePeerDependencies:
@@ -3845,19 +3841,19 @@ snapshots:
 
   '@octokit/plugin-enterprise-rest@6.0.1': {}
 
-  '@octokit/plugin-paginate-rest@6.1.2(@octokit/core@4.2.4)':
+  '@octokit/plugin-paginate-rest@6.1.2(@octokit/core@4.2.4(encoding@0.1.13))':
     dependencies:
-      '@octokit/core': 4.2.4
+      '@octokit/core': 4.2.4(encoding@0.1.13)
       '@octokit/tsconfig': 1.0.2
       '@octokit/types': 9.3.2
 
-  '@octokit/plugin-request-log@1.0.4(@octokit/core@4.2.4)':
+  '@octokit/plugin-request-log@1.0.4(@octokit/core@4.2.4(encoding@0.1.13))':
     dependencies:
-      '@octokit/core': 4.2.4
+      '@octokit/core': 4.2.4(encoding@0.1.13)
 
-  '@octokit/plugin-rest-endpoint-methods@7.2.3(@octokit/core@4.2.4)':
+  '@octokit/plugin-rest-endpoint-methods@7.2.3(@octokit/core@4.2.4(encoding@0.1.13))':
     dependencies:
-      '@octokit/core': 4.2.4
+      '@octokit/core': 4.2.4(encoding@0.1.13)
       '@octokit/types': 10.0.0
 
   '@octokit/request-error@3.0.3':
@@ -3866,23 +3862,23 @@ snapshots:
       deprecation: 2.3.1
       once: 1.4.0
 
-  '@octokit/request@6.2.8':
+  '@octokit/request@6.2.8(encoding@0.1.13)':
     dependencies:
       '@octokit/endpoint': 7.0.6
       '@octokit/request-error': 3.0.3
       '@octokit/types': 9.3.2
       is-plain-object: 5.0.0
-      node-fetch: 2.6.7
+      node-fetch: 2.6.7(encoding@0.1.13)
       universal-user-agent: 6.0.1
     transitivePeerDependencies:
       - encoding
 
-  '@octokit/rest@19.0.11':
+  '@octokit/rest@19.0.11(encoding@0.1.13)':
     dependencies:
-      '@octokit/core': 4.2.4
-      '@octokit/plugin-paginate-rest': 6.1.2(@octokit/core@4.2.4)
-      '@octokit/plugin-request-log': 1.0.4(@octokit/core@4.2.4)
-      '@octokit/plugin-rest-endpoint-methods': 7.2.3(@octokit/core@4.2.4)
+      '@octokit/core': 4.2.4(encoding@0.1.13)
+      '@octokit/plugin-paginate-rest': 6.1.2(@octokit/core@4.2.4(encoding@0.1.13))
+      '@octokit/plugin-request-log': 1.0.4(@octokit/core@4.2.4(encoding@0.1.13))
+      '@octokit/plugin-rest-endpoint-methods': 7.2.3(@octokit/core@4.2.4(encoding@0.1.13))
     transitivePeerDependencies:
       - encoding
 
@@ -3899,17 +3895,22 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@rollup/plugin-typescript@11.1.6(typescript@5.4.5)':
+  '@rollup/plugin-typescript@11.1.6(rollup@4.30.1)(tslib@2.8.1)(typescript@5.4.5)':
     dependencies:
-      '@rollup/pluginutils': 5.1.4
+      '@rollup/pluginutils': 5.1.4(rollup@4.30.1)
       resolve: 1.22.10
       typescript: 5.4.5
+    optionalDependencies:
+      rollup: 4.30.1
+      tslib: 2.8.1
 
-  '@rollup/pluginutils@5.1.4':
+  '@rollup/pluginutils@5.1.4(rollup@4.30.1)':
     dependencies:
       '@types/estree': 1.0.6
       estree-walker: 2.0.2
       picomatch: 4.0.2
+    optionalDependencies:
+      rollup: 4.30.1
 
   '@rollup/rollup-android-arm-eabi@4.30.1':
     optional: true
@@ -3970,17 +3971,17 @@ snapshots:
 
   '@rushstack/node-core-library@4.0.2(@types/node@20.17.12)':
     dependencies:
-      '@types/node': 20.17.12
       fs-extra: 7.0.1
       import-lazy: 4.0.0
       jju: 1.4.0
       resolve: 1.22.10
       semver: 7.5.4
       z-schema: 5.0.5
+    optionalDependencies:
+      '@types/node': 20.17.12
 
   '@rushstack/node-core-library@5.10.1(@types/node@20.17.12)':
     dependencies:
-      '@types/node': 20.17.12
       ajv: 8.13.0
       ajv-draft-04: 1.0.0(ajv@8.13.0)
       ajv-formats: 3.0.1(ajv@8.13.0)
@@ -3989,6 +3990,8 @@ snapshots:
       jju: 1.4.0
       resolve: 1.22.10
       semver: 7.5.4
+    optionalDependencies:
+      '@types/node': 20.17.12
 
   '@rushstack/rig-package@0.5.2':
     dependencies:
@@ -4003,14 +4006,16 @@ snapshots:
   '@rushstack/terminal@0.10.0(@types/node@20.17.12)':
     dependencies:
       '@rushstack/node-core-library': 4.0.2(@types/node@20.17.12)
-      '@types/node': 20.17.12
       supports-color: 8.1.1
+    optionalDependencies:
+      '@types/node': 20.17.12
 
   '@rushstack/terminal@0.14.4(@types/node@20.17.12)':
     dependencies:
       '@rushstack/node-core-library': 5.10.1(@types/node@20.17.12)
-      '@types/node': 20.17.12
       supports-color: 8.1.1
+    optionalDependencies:
+      '@types/node': 20.17.12
 
   '@rushstack/ts-command-line@4.19.1(@types/node@20.17.12)':
     dependencies:
@@ -4146,8 +4151,9 @@ snapshots:
       minimatch: 9.0.5
       muggle-string: 0.3.1
       path-browserify: 1.0.1
-      typescript: 5.4.5
       vue-template-compiler: 2.7.16
+    optionalDependencies:
+      typescript: 5.4.5
 
   '@vue/language-core@2.1.10(typescript@5.4.5)':
     dependencies:
@@ -4159,6 +4165,7 @@ snapshots:
       minimatch: 9.0.5
       muggle-string: 0.4.1
       path-browserify: 1.0.1
+    optionalDependencies:
       typescript: 5.4.5
 
   '@vue/shared@3.5.13': {}
@@ -4203,11 +4210,11 @@ snapshots:
       indent-string: 4.0.0
 
   ajv-draft-04@1.0.0(ajv@8.13.0):
-    dependencies:
+    optionalDependencies:
       ajv: 8.13.0
 
   ajv-formats@3.0.1(ajv@8.13.0):
-    dependencies:
+    optionalDependencies:
       ajv: 8.13.0
 
   ajv@6.12.6:
@@ -4463,10 +4470,6 @@ snapshots:
       strip-ansi: 6.0.1
       wcwidth: 1.0.1
 
-  com.outsystems.plugins.osgeolocation@file:packages/cordova-plugin:
-    dependencies:
-      '@capacitor/synapse': 1.0.1
-
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
@@ -4608,6 +4611,7 @@ snapshots:
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       parse-json: 5.2.0
+    optionalDependencies:
       typescript: 5.4.5
 
   cross-spawn@7.0.6:
@@ -5362,15 +5366,15 @@ snapshots:
 
   kolorist@1.8.0: {}
 
-  lerna@8.1.9:
+  lerna@8.1.9(encoding@0.1.13):
     dependencies:
-      '@lerna/create': 8.1.9(typescript@5.4.5)
+      '@lerna/create': 8.1.9(encoding@0.1.13)(typescript@5.4.5)
       '@npmcli/arborist': 7.5.4
       '@npmcli/package-json': 5.2.0
       '@npmcli/run-script': 8.1.0
       '@nx/devkit': 20.3.1(nx@20.3.1)
       '@octokit/plugin-enterprise-rest': 6.0.1
-      '@octokit/rest': 19.0.11
+      '@octokit/rest': 19.0.11(encoding@0.1.13)
       aproba: 2.0.0
       byte-size: 8.1.1
       chalk: 4.1.0
@@ -5409,7 +5413,7 @@ snapshots:
       make-dir: 4.0.0
       minimatch: 3.0.5
       multimatch: 5.0.0
-      node-fetch: 2.6.7
+      node-fetch: 2.6.7(encoding@0.1.13)
       npm-package-arg: 11.0.2
       npm-packlist: 8.0.2
       npm-registry-fetch: 17.1.0
@@ -5721,9 +5725,11 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  node-fetch@2.6.7:
+  node-fetch@2.6.7(encoding@0.1.13):
     dependencies:
       whatwg-url: 5.0.0
+    optionalDependencies:
+      encoding: 0.1.13
 
   node-gyp@10.3.1:
     dependencies:
@@ -6605,26 +6611,27 @@ snapshots:
 
   validator@13.12.0: {}
 
-  vite-plugin-dts@3.9.1(@types/node@20.17.12)(typescript@5.4.5)(vite@5.4.11):
+  vite-plugin-dts@3.9.1(@types/node@20.17.12)(rollup@4.30.1)(typescript@5.4.5)(vite@5.4.11(@types/node@20.17.12)):
     dependencies:
       '@microsoft/api-extractor': 7.43.0(@types/node@20.17.12)
-      '@rollup/pluginutils': 5.1.4
+      '@rollup/pluginutils': 5.1.4(rollup@4.30.1)
       '@vue/language-core': 1.8.27(typescript@5.4.5)
       debug: 4.4.0
       kolorist: 1.8.0
       magic-string: 0.30.17
       typescript: 5.4.5
-      vite: 5.4.11(@types/node@20.17.12)
       vue-tsc: 1.8.27(typescript@5.4.5)
+    optionalDependencies:
+      vite: 5.4.11(@types/node@20.17.12)
     transitivePeerDependencies:
       - '@types/node'
       - rollup
       - supports-color
 
-  vite-plugin-dts@4.4.0(@types/node@20.17.12)(typescript@5.4.5)(vite@5.4.11):
+  vite-plugin-dts@4.4.0(@types/node@20.17.12)(rollup@4.30.1)(typescript@5.4.5)(vite@5.4.11(@types/node@20.17.12)):
     dependencies:
       '@microsoft/api-extractor': 7.49.0(@types/node@20.17.12)
-      '@rollup/pluginutils': 5.1.4
+      '@rollup/pluginutils': 5.1.4(rollup@4.30.1)
       '@volar/typescript': 2.4.11
       '@vue/language-core': 2.1.10(typescript@5.4.5)
       compare-versions: 6.1.1
@@ -6633,6 +6640,7 @@ snapshots:
       local-pkg: 0.5.1
       magic-string: 0.30.17
       typescript: 5.4.5
+    optionalDependencies:
       vite: 5.4.11(@types/node@20.17.12)
     transitivePeerDependencies:
       - '@types/node'
@@ -6641,11 +6649,11 @@ snapshots:
 
   vite@5.4.11(@types/node@20.17.12):
     dependencies:
-      '@types/node': 20.17.12
       esbuild: 0.21.5
       postcss: 8.4.49
       rollup: 4.30.1
     optionalDependencies:
+      '@types/node': 20.17.12
       fsevents: 2.3.3
 
   vscode-uri@3.0.8: {}


### PR DESCRIPTION
## Description

There are additional issues with MABS 12 builds, related with this cordova plugin, that have been fixed in this PR:

- For Synapse to work with Cordova on Capacitor shell, it required an update - See https://github.com/ionic-team/synapse/pull/1  
- `plugin.xml` required an update, otherwise plugin wasn't being recognized as a cordova plugin.
- `package.json` at root required proper name and version, even though the actual main `package.json` is at `packages/cordova-plugin`; this is because `npm pack` (used by MABS 12) was failing.
    - Alternatively, we would have the cordova plugin at the root of the repository; or we would publish the cordova plugin package to npm (would require a plugin.xml to be in `packages/cordova-plugin`) - although with the latter the Synapse dependency could stop working due to an issue with getting dependencies from tarballs with npm / MABS 12. This was the least-effort solution that I found.



## Context

https://outsystemsrd.atlassian.net/browse/RMET-4066

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [X] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [ ] iOS
- [X] JavaScript

## Tests

Full regression Testing location plugin and sample app on O11 and ODC, on available MABS versions (10, 11 and 12).

Tests on both native Android, iOS. Also testing PWAs.

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [ ] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
