### PR TITLE
chore: Properly check if synapse is defined

### DIFF
--- a/packages/outsystems-wrapper/src/index.ts
+++ b/packages/outsystems-wrapper/src/index.ts
@@ -264,7 +264,7 @@ class OSGeolocation {
      */
     #isSynapseDefined(): boolean {
         // @ts-ignore
-        return typeof (CapacitorUtils) !== "undefined"
+        return typeof (CapacitorUtils) !== "undefined" && typeof (CapacitorUtils.Synapse) !== "undefined" && typeof (CapacitorUtils.Synapse.Geolocation) !== "undefined"
     }
 }
 


### PR DESCRIPTION
Explicitly check for CapacitorUtils.Synapse.Filesystem before using it - instead of just CapacitorUtils. The reason being that this plugin may not have Synapse available, but other plugins do (e.g. CapacitorUtils.Synapse.Filesystem is available), which could cause the wrapper to not work.

Discovered in https://github.com/ionic-team/cordova-outsystems-file/pull/8 - replicated here.