### PR TITLE
RMET-4294 :: Watch location callback id for Capacitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### 2025-07-01
+
+- Fix: getting watch id for Capacitor in OutSystems Wrapper.
+
 ## [1.0.1]
 
 ### 2025-02-14

--- a/packages/outsystems-wrapper/src/index.ts
+++ b/packages/outsystems-wrapper/src/index.ts
@@ -106,6 +106,9 @@ class OSGeolocation {
             }
             error(e)
         }
+        const watchAddedCallback = (callbackId: string) => {
+            this.#callbackIdsMap[watchId] = callbackId;
+        }
 
         if (options.timeout !== Infinity) {
             // If the timeout value was not set to Infinity (default), then
@@ -120,7 +123,7 @@ class OSGeolocation {
             // For the case of watch location, capacitor returns a callback id that should be stored on the wrapper to make sure watches are cleared properly
             //  So in other words, Synapse can't be used in watchPosition for Capacitor.
             // @ts-ignore
-            let callbackId: string = Capacitor.Plugins.Geolocation.watchPosition(
+            Capacitor.Plugins.Geolocation.watchPosition(
                 options, 
                 (position: Position | OSGLOCPosition, err?: any) => {
                     if (err) {
@@ -130,8 +133,7 @@ class OSGeolocation {
                         successCallback(position)
                     }
                 }
-            );
-            this.#callbackIdsMap[watchId] = callbackId;
+            ).then(watchAddedCallback);
         } else {
             // @ts-ignore
             cordova.plugins.Geolocation.watchPosition(options, successCallback, errorCallback)


### PR DESCRIPTION
## Description

We were trying to assign the callback ID for capacitor plugins `watchPosition` directly, which was working before, but it's not working in the most recent OutSystems MABS builds.

To be frank, I'm surprised this worked to begin with, since `watchPosition` returns a `Promise` for the Capacitor Plugin, updated the OutSystems wrapper to get the result in the Promise callback instead.

## Context

https://outsystemsrd.atlassian.net/browse/RMET-4294

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [ ] iOS
- [x] JavaScript

## Tests

You can use the latest "Location Sample Apps" builds from ODC to check that the watch location and clear watch are working in both Android and iOS. 

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [ ] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
