### PR TITLE
RMET-4396 :: WatchPosition interfering with GetLocation on latest major release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
-### Unreleased
+## [1.0.3]
 
+### 2025-08-11
 - Fix(ios): fixes an issue where the plugin stops receiving location updates after calling the clearWatch method.
 - Chore(iOS): update native library IONGeolocationLib to version 1.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+
+### Unreleased
+
+- Fix(ios): fixes an issue where the plugin stops receiving location updates after calling the clearWatch method.
+- Chore(iOS): update native library IONGeolocationLib to version 1.0.1
+
 ## [1.0.2]
 
 ### 2025-07-08

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.outsystems.plugins.geolocation",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": true,
   "dependencies": {},
   "scripts": {

--- a/packages/cordova-plugin/ios/OSGeolocationPlugin.swift
+++ b/packages/cordova-plugin/ios/OSGeolocationPlugin.swift
@@ -167,6 +167,7 @@ private extension OSGeolocation {
     }
 
     func handleLocationRequest(_ enableHighAccuracy: Bool, watchUUID: String? = nil, _ callbackId: String) {
+        bindLocationPublisher()
         let configurationModel = IONGLOCConfigurationModel.createWithAccuracy(enableHighAccuracy)
         locationService?.updateConfiguration(configurationModel)
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -50,7 +50,7 @@
                 <source url="https://cdn.cocoapods.org/"/>
             </config>
             <pods use-frameworks="true">
-                <pod name="IONGeolocationLib" spec="1.0.0" />
+                <pod name="IONGeolocationLib" spec="1.0.1" />
             </pods>
         </podspec>
     </platform>

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="com.outsystems.plugins.geolocation" version="1.0.2" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="com.outsystems.plugins.geolocation" version="1.0.3" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>OSGeolocationPlugin</name>
     <description>OutSystems' cordova geolocation plugin</description>
     <author>OutSystems Inc</author>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fixes an issue where the plugin stops receiving location updates after calling the clearWatch method.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
https://outsystemsrd.atlassian.net/browse/RMET-4396

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Tested locally with Location Sample App

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
