### PR TITLE
feat(android): Allow removal of location permissions from manifest

### DIFF
--- a/build-actions/README.md
+++ b/build-actions/README.md
@@ -1,0 +1,53 @@
+# OSGeolocationPlugin Build Actions
+
+This plugin requires location permissions in `AndroidManifest.xml`. The build action controls which permissions are declared based on the accuracy tier the consuming app needs.
+
+## What this configures
+
+### Android
+
+| Action | Purpose |
+|--------|---------|
+| `manifest` merge | Adds `ACCESS_FINE_LOCATION` and `ACCESS_COARSE_LOCATION` unconditionally |
+| `manifest` delete | Removes `ACCESS_FINE_LOCATION` when `LOCATION_PERMISSION_TYPE` is `APPROXIMATE` or `NONE` |
+| `manifest` delete | Removes `ACCESS_COARSE_LOCATION` when `LOCATION_PERMISSION_TYPE` is `NONE` |
+
+## Variables
+
+| Variable | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `LOCATION_PERMISSION_TYPE` | string | no | `PRECISE` | Controls which location permissions are declared in the manifest. Both permissions are added unconditionally and then pruned based on this value: `PRECISE` keeps both, `APPROXIMATE` removes `ACCESS_FINE_LOCATION`, `NONE` removes both. Unset or empty string behaves as `PRECISE`. Values are case-sensitive. |
+
+## ODC Setup
+
+1. In ODC Studio, add `buildAction.json` as a resource and set **Deploy Action**
+   to **Deploy to Target Directory**.
+2. Configure extensibility to reference the file and resolve its variables.
+   The path depends on the target:
+   - **ODC app:** App > Edit app properties > Extensibility
+   - **ODC Mobile Library (plugin):** Library > Edit library properties > Extensibility
+
+   ```json
+   {
+       "buildConfigurations": {
+           "buildAction": {
+               "config": "$resources.buildAction.json",
+               "parameters": {
+                   "LOCATION_PERMISSION_TYPE": "PRECISE"
+               }
+           }
+       }
+   }
+   ```
+
+   Values in `parameters` can be hardcoded literals or extensibility setting references
+   (`$extensibilitySettings.SettingName`). Use extensibility settings if consuming apps
+   should be able to choose the accuracy tier. The plugin developer creates the settings
+   in ODC Studio: right-click **Extensibility Settings** in the context pane →
+   **Add Extensibility Setting**. The consuming app then sets values in ODC Portal →
+   app → **Mobile distribution** → **Extensibility settings**.
+
+3. Build in the ODC Portal using MABS 12 or greater:
+   - **ODC app:** build the app directly.
+   - **ODC Mobile Library (plugin):** consume the library in an ODC app, then
+     build that app.

--- a/build-actions/buildAction.json
+++ b/build-actions/buildAction.json
@@ -1,0 +1,39 @@
+{
+    "variables": {
+        "LOCATION_PERMISSION_TYPE": {
+            "type": "string",
+            "default": "PRECISE"
+        }
+    },
+    "platforms": {
+        "android": {
+            "manifest": [
+                {
+                    "file": "AndroidManifest.xml",
+                    "target": "manifest",
+                    "merge": "<manifest>\n  <uses-permission android:name=\"android.permission.ACCESS_FINE_LOCATION\" />\n</manifest>"
+                },
+                {
+                    "file": "AndroidManifest.xml",
+                    "target": "manifest",
+                    "merge": "<manifest>\n  <uses-permission android:name=\"android.permission.ACCESS_COARSE_LOCATION\" />\n</manifest>"
+                },
+                {
+                    "file": "AndroidManifest.xml",
+                    "condition": "eq($LOCATION_PERMISSION_TYPE, APPROXIMATE)",
+                    "delete": "//uses-permission[@android:name='android.permission.ACCESS_FINE_LOCATION']"
+                },
+                {
+                    "file": "AndroidManifest.xml",
+                    "condition": "eq($LOCATION_PERMISSION_TYPE, NONE)",
+                    "delete": "//uses-permission[@android:name='android.permission.ACCESS_FINE_LOCATION']"
+                },
+                {
+                    "file": "AndroidManifest.xml",
+                    "condition": "eq($LOCATION_PERMISSION_TYPE, NONE)",
+                    "delete": "//uses-permission[@android:name='android.permission.ACCESS_COARSE_LOCATION']"
+                }
+            ]
+        }
+    }
+}

--- a/hooks/androidLocationPermissions.js
+++ b/hooks/androidLocationPermissions.js
@@ -1,0 +1,52 @@
+const fs = require('fs');
+const path = require('path');
+const { ConfigParser } = require('cordova-common');
+const { DOMParser, XMLSerializer } = require('@xmldom/xmldom');
+
+const PRECISE = 'PRECISE';
+const APPROXIMATE = 'APPROXIMATE';
+const NONE = 'NONE';
+const FINE_LOCATION = 'android.permission.ACCESS_FINE_LOCATION';
+const COARSE_LOCATION = 'android.permission.ACCESS_COARSE_LOCATION';
+
+module.exports = function(context) {
+    const projectRoot = context.opts.cordova.project ? context.opts.cordova.project.root : context.opts.projectRoot;
+    const configXML = path.join(projectRoot, 'config.xml');
+    const configParser = new ConfigParser(configXML);
+
+    let locationPermissionType = configParser.getPlatformPreference('LOCATION_PERMISSION_TYPE', 'android').toUpperCase();
+
+    if (locationPermissionType !== PRECISE && locationPermissionType !== APPROXIMATE && locationPermissionType !== NONE) {
+        locationPermissionType = PRECISE;
+    }
+
+    if (locationPermissionType === NONE) {
+        return;
+    }
+
+    const manifestFilePath = path.join(projectRoot, 'platforms/android/app/src/main/AndroidManifest.xml');
+    const manifestXmlString = fs.readFileSync(manifestFilePath, 'utf-8');
+
+    const parser = new DOMParser();
+    const manifestXmlDoc = parser.parseFromString(manifestXmlString, 'text/xml');
+
+    if (locationPermissionType === PRECISE) {
+        addPermissionToManifest(manifestXmlDoc, FINE_LOCATION);
+    }
+    addPermissionToManifest(manifestXmlDoc, COARSE_LOCATION);
+
+    const serializer = new XMLSerializer();
+    const updatedManifestXmlString = serializer.serializeToString(manifestXmlDoc);
+    fs.writeFileSync(manifestFilePath, updatedManifestXmlString, 'utf-8');
+};
+
+function addPermissionToManifest(manifestXmlDoc, permission) {
+    const existingPermissions = Array.from(manifestXmlDoc.getElementsByTagName('uses-permission'));
+    const alreadyExists = existingPermissions.some(el => el.getAttribute('android:name') === permission);
+
+    if (!alreadyExists) {
+        const newPermission = manifestXmlDoc.createElement('uses-permission');
+        newPermission.setAttribute('android:name', permission);
+        manifestXmlDoc.documentElement.appendChild(newPermission);
+    }
+}

--- a/hooks/androidLocationPermissions.js
+++ b/hooks/androidLocationPermissions.js
@@ -21,6 +21,8 @@ module.exports = function(context) {
     }
 
     if (locationPermissionType === NONE) {
+        // Returning without writing to the manifest is sufficient — this plugin no longer declares
+        // permissions statically, so nothing needs to be removed.
         return;
     }
 

--- a/hooks/androidLocationPermissions.js
+++ b/hooks/androidLocationPermissions.js
@@ -14,7 +14,7 @@ module.exports = function(context) {
     const configXML = path.join(projectRoot, 'config.xml');
     const configParser = new ConfigParser(configXML);
 
-    let locationPermissionType = configParser.getPlatformPreference('LOCATION_PERMISSION_TYPE', 'android').toUpperCase();
+    let locationPermissionType = configParser.getPlatformPreference('LOCATION_PERMISSION_TYPE', 'android');
 
     if (locationPermissionType !== PRECISE && locationPermissionType !== APPROXIMATE && locationPermissionType !== NONE) {
         locationPermissionType = PRECISE;

--- a/packages/cordova-plugin/android/OSGeolocation.kt
+++ b/packages/cordova-plugin/android/OSGeolocation.kt
@@ -14,9 +14,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
 import org.apache.cordova.CallbackContext
-import org.apache.cordova.CordovaInterface
 import org.apache.cordova.CordovaPlugin
-import org.apache.cordova.CordovaWebView
 import org.apache.cordova.PermissionHelper
 import org.apache.cordova.PluginResult
 import org.json.JSONArray
@@ -44,8 +42,8 @@ class OSGeolocation : CordovaPlugin() {
         private const val LOG_TAG = "OSGeolocation"
     }
 
-    override fun initialize(cordova: CordovaInterface, webView: CordovaWebView) {
-        super.initialize(cordova, webView)
+    override fun pluginInitialize() {
+        super.pluginInitialize()
 
         coroutineScope = CoroutineScope(Dispatchers.Main)
         val activityLauncher = cordova.activity.registerForActivityResult(
@@ -351,7 +349,7 @@ class OSGeolocation : CordovaPlugin() {
             for (permission in permissionsInPackage) {
                 if (permission == Manifest.permission.ACCESS_FINE_LOCATION) {
                     // adding both permissions in the event that only FINE is declared in manifest
-                    //  since ACCESS_FINE_LOCATION would include ACCESS_COARSE_LOCATION, 
+                    //  since ACCESS_FINE_LOCATION would include ACCESS_COARSE_LOCATION,
                     //  technically only the former can be declared.
                     permissionList.addAll(
                         listOf(
@@ -369,6 +367,14 @@ class OSGeolocation : CordovaPlugin() {
         return permissionList.toSet().toTypedArray()
     }
 
+    /**
+     * Still calling deprecated onRequestPermissionResult instead of onRequestPermissionsResult
+     * Because cordova-android had a bug where onRequestPermissionsResult was not called
+     * Fixed in https://github.com/apache/cordova-android/pull/1855
+     * But existing MABS versions do not have that PR yet in the cordova-android fork
+     * https://github.com/OutSystems/cordova-android;
+     * so we'll have to wait for that until we can change to onRequestPermissionsResult here.
+     */
     override fun onRequestPermissionResult(
         requestCode: Int,
         permissions: Array<out String>,

--- a/packages/cordova-plugin/android/OSGeolocation.kt
+++ b/packages/cordova-plugin/android/OSGeolocation.kt
@@ -2,6 +2,7 @@ package com.outsystems.plugins.geolocation
 
 import android.Manifest
 import android.content.pm.PackageManager
+import android.util.Log
 import androidx.activity.result.contract.ActivityResultContracts
 import com.google.gson.Gson
 import io.ionic.libs.iongeolocationlib.controller.IONGLOCController
@@ -40,6 +41,7 @@ class OSGeolocation : CordovaPlugin() {
         private const val MAXIMUM_AGE = "maximumAge"
         private const val ENABLE_HIGH_ACCURACY = "enableHighAccuracy"
         private const val ENABLE_FALLBACK = "enableLocationFallback"
+        private const val LOG_TAG = "OSGeolocation"
     }
 
     override fun initialize(cordova: CordovaInterface, webView: CordovaWebView) {
@@ -279,10 +281,15 @@ class OSGeolocation : CordovaPlugin() {
         permissionsFlow = MutableSharedFlow(replay = 1)
 
         // first, we request permissions if necessary
-        if (hasLocationPermissions()) {
+        val permissions = getDeclaredPermissions()
+        if (permissions.isEmpty()) {
+            callbackContext.sendError(OSGeolocationErrors.LOCATION_MANIFEST_PERMISSIONS_MISSING)
+            return
+        }
+        if (hasLocationPermissions(permissions)) {
             permissionsFlow.emit(OSGeolocationPermissionEvents.Granted)
         } else { // request necessary permissions
-            requestLocationPermissions()
+            requestLocationPermissions(permissions)
         }
 
         // collect the flow to handle permission request result
@@ -299,8 +306,8 @@ class OSGeolocation : CordovaPlugin() {
      * Helper function to determine Location permission state
      * @return Boolean indicating if permissions are granted or not
      */
-    private fun hasLocationPermissions(): Boolean {
-        for (permission in listOf(Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION)) {
+    private fun hasLocationPermissions(permissions: Array<String>): Boolean {
+        for (permission in permissions) {
             if (!PermissionHelper.hasPermission(this, permission)) {
                 return false
             }
@@ -311,14 +318,45 @@ class OSGeolocation : CordovaPlugin() {
     /**
      * Helper function to request location permissions
      */
-    private fun requestLocationPermissions() {
+    private fun requestLocationPermissions(permissions: Array<String>) {
         PermissionHelper.requestPermissions(
             this,
             LOCATION_PERMISSIONS_REQUEST_CODE,
-            listOf(
-                Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION
-            ).toTypedArray()
+            permissions
         )
+    }
+
+    /**
+     * Get the location permissions to request based on the ones declared in app's manifest.
+     *
+     * @return the array of declared location permissions, expected size 0-2
+     */
+    private fun getDeclaredPermissions(): Array<String> {
+        val permissionList = mutableListOf<String>()
+        try {
+            val packageManager = cordova.activity.packageManager
+            val permissionsInPackage = packageManager.getPackageInfo(
+                cordova.activity.packageName, PackageManager.GET_PERMISSIONS
+            ).requestedPermissions ?: arrayOf()
+            for (permission in permissionsInPackage) {
+                if (permission == Manifest.permission.ACCESS_FINE_LOCATION) {
+                    // adding both permissions in the event that only FINE is declared in manifest
+                    //  since ACCESS_FINE_LOCATION would include ACCESS_COARSE_LOCATION, 
+                    //  technically only the former can be declared.
+                    permissionList.addAll(
+                        listOf(
+                            Manifest.permission.ACCESS_FINE_LOCATION,
+                            Manifest.permission.ACCESS_COARSE_LOCATION
+                        )
+                    )
+                } else if (permission == Manifest.permission.ACCESS_COARSE_LOCATION) {
+                    permissionList.add(permission)
+                }
+            }
+        } catch (e: Exception) {
+            Log.d(LOG_TAG, e.message.toString())
+        }
+        return permissionList.toSet().toTypedArray()
     }
 
     override fun onRequestPermissionResult(

--- a/packages/cordova-plugin/android/OSGeolocation.kt
+++ b/packages/cordova-plugin/android/OSGeolocation.kt
@@ -343,23 +343,17 @@ class OSGeolocation : CordovaPlugin() {
      * @return the array of declared location permissions, expected size 0-2
      */
     private fun getDeclaredPermissions(enableHighAccuracy: Boolean): Array<String> {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
-            // Below Android 12 there is no FINE/COARSE distinction, so always request both.
-            return arrayOf(
-                Manifest.permission.ACCESS_FINE_LOCATION,
-                Manifest.permission.ACCESS_COARSE_LOCATION
-            )
-        }
-
-        // On Android >= 12, only request what is declared in the manifest and needed for the accuracy level.
         val manifestPermissions = getManifestPermissions()
         // ACCESS_FINE_LOCATION implicitly grants coarse access, so a FINE-only manifest still covers COARSE.
         val hasFine = Manifest.permission.ACCESS_FINE_LOCATION in manifestPermissions
         val hasCoarse = hasFine || Manifest.permission.ACCESS_COARSE_LOCATION in manifestPermissions
 
         val permissions = mutableSetOf<String>()
-        if (hasFine && enableHighAccuracy) permissions.add(Manifest.permission.ACCESS_FINE_LOCATION)
         if (hasCoarse) permissions.add(Manifest.permission.ACCESS_COARSE_LOCATION)
+        // On Android >= 12, FINE is only requested for high-accuracy calls.
+        // Below Android 12 there is no granular permission, so always request FINE if declared.
+        val shouldRequestFine = hasFine && (Build.VERSION.SDK_INT < Build.VERSION_CODES.S || enableHighAccuracy)
+        if (shouldRequestFine) permissions.add(Manifest.permission.ACCESS_FINE_LOCATION)
         return permissions.toTypedArray()
     }
 

--- a/packages/cordova-plugin/android/OSGeolocation.kt
+++ b/packages/cordova-plugin/android/OSGeolocation.kt
@@ -343,40 +343,39 @@ class OSGeolocation : CordovaPlugin() {
      * @return the array of declared location permissions, expected size 0-2
      */
     private fun getDeclaredPermissions(enableHighAccuracy: Boolean): Array<String> {
-        val permissionList = mutableListOf<String>()
-        try {
-            val packageManager = cordova.activity.packageManager
-            val permissionsInPackage = packageManager.getPackageInfo(
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+            // Below Android 12 there is no FINE/COARSE distinction, so always request both.
+            return arrayOf(
+                Manifest.permission.ACCESS_FINE_LOCATION,
+                Manifest.permission.ACCESS_COARSE_LOCATION
+            )
+        }
+
+        // On Android >= 12, only request what is declared in the manifest and needed for the accuracy level.
+        val manifestPermissions = getManifestPermissions()
+        // ACCESS_FINE_LOCATION implicitly grants coarse access, so a FINE-only manifest still covers COARSE.
+        val hasFine = Manifest.permission.ACCESS_FINE_LOCATION in manifestPermissions
+        val hasCoarse = hasFine || Manifest.permission.ACCESS_COARSE_LOCATION in manifestPermissions
+
+        val permissions = mutableSetOf<String>()
+        if (hasFine && enableHighAccuracy) permissions.add(Manifest.permission.ACCESS_FINE_LOCATION)
+        if (hasCoarse) permissions.add(Manifest.permission.ACCESS_COARSE_LOCATION)
+        return permissions.toTypedArray()
+    }
+
+    /**
+     * Returns the set of permissions declared in the app's manifest.
+     */
+    private fun getManifestPermissions(): Set<String> {
+        return try {
+            val packageInfo = cordova.activity.packageManager.getPackageInfo(
                 cordova.activity.packageName, PackageManager.GET_PERMISSIONS
-            ).requestedPermissions ?: arrayOf()
-            for (permission in permissionsInPackage) {
-                if (permission == Manifest.permission.ACCESS_FINE_LOCATION) {
-                    // adding both permissions in the event that only FINE is declared in manifest
-                    //  since ACCESS_FINE_LOCATION would include ACCESS_COARSE_LOCATION,
-                    //  technically only the former can be declared.
-                    permissionList.addAll(
-                        listOf(
-                            Manifest.permission.ACCESS_FINE_LOCATION,
-                            Manifest.permission.ACCESS_COARSE_LOCATION
-                        )
-                    )
-                } else if (permission == Manifest.permission.ACCESS_COARSE_LOCATION) {
-                    permissionList.add(permission)
-                }
-            }
+            )
+            (packageInfo.requestedPermissions ?: emptyArray()).toHashSet()
         } catch (e: Exception) {
             Log.d(LOG_TAG, e.message.toString())
+            emptySet()
         }
-        val permissionSet = permissionList.toMutableSet()
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
-            // below Android 12 there is no distinction between FINE and COARSE
-            permissionSet.add(Manifest.permission.ACCESS_FINE_LOCATION)
-        } else if (!enableHighAccuracy) {
-            // on Android >= 12, ACCESS_FINE_LOCATION should only be required for PRIORTY_HIGH_ACCURACY
-            //  if the caller does not request high accuracy, then ACCESS_FINE_LOCATION isn't required
-            permissionSet.remove(Manifest.permission.ACCESS_FINE_LOCATION)
-        }
-        return permissionSet.toTypedArray()
     }
 
     /**

--- a/packages/cordova-plugin/android/OSGeolocation.kt
+++ b/packages/cordova-plugin/android/OSGeolocation.kt
@@ -2,6 +2,7 @@ package com.outsystems.plugins.geolocation
 
 import android.Manifest
 import android.content.pm.PackageManager
+import android.os.Build
 import android.util.Log
 import androidx.activity.result.contract.ActivityResultContracts
 import com.google.gson.Gson
@@ -102,14 +103,13 @@ class OSGeolocation : CordovaPlugin() {
         }
 
         coroutineScope.launch {
-            handleLocationPermission(callbackContext) {
-                val locationOptions = IONGLOCLocationOptions(
-                    options.getLong(TIMEOUT),
-                    options.getLong(MAXIMUM_AGE),
-                    options.getBoolean(ENABLE_HIGH_ACCURACY),
-                    enableLocationManagerFallback = options.optBoolean(ENABLE_FALLBACK, true)
-                )
-
+            val locationOptions = IONGLOCLocationOptions(
+                options.getLong(TIMEOUT),
+                options.getLong(MAXIMUM_AGE),
+                options.getBoolean(ENABLE_HIGH_ACCURACY),
+                enableLocationManagerFallback = options.optBoolean(ENABLE_FALLBACK, true)
+            )
+            handleLocationPermission(callbackContext, locationOptions.enableHighAccuracy) {
                 val locationResult =
                     controller.getCurrentPosition(cordova.activity, locationOptions)
 
@@ -138,14 +138,13 @@ class OSGeolocation : CordovaPlugin() {
         val watchId = options.getString(ID)
 
         coroutineScope.launch {
-            handleLocationPermission(callbackContext) {
-                val locationOptions = IONGLOCLocationOptions(
-                    timeout = options.getLong(TIMEOUT),
-                    maximumAge = options.getLong(MAXIMUM_AGE),
-                    enableHighAccuracy = options.getBoolean(ENABLE_HIGH_ACCURACY),
-                    enableLocationManagerFallback = options.optBoolean(ENABLE_FALLBACK, true)
-                )
-
+            val locationOptions = IONGLOCLocationOptions(
+                timeout = options.getLong(TIMEOUT),
+                maximumAge = options.getLong(MAXIMUM_AGE),
+                enableHighAccuracy = options.getBoolean(ENABLE_HIGH_ACCURACY),
+                enableLocationManagerFallback = options.optBoolean(ENABLE_FALLBACK, true)
+            )
+            handleLocationPermission(callbackContext, locationOptions.enableHighAccuracy) {
                 controller.addWatch(cordova.activity, locationOptions, watchId).collect { result ->
                     result.onSuccess { locationList ->
                         locationList.forEach { locationResult ->
@@ -280,16 +279,18 @@ class OSGeolocation : CordovaPlugin() {
     /**
      * Helper function to handle the location permission request using a Flow
      * @param callbackContext CallbackContext to use in case an error should be returned
+     * @param enableHighAccuracy true if meant to do a high accuracy location request, false otherwise
      * @param onLocationGranted callback to use in case permissions are granted
      */
     private suspend fun handleLocationPermission(
         callbackContext: CallbackContext,
+        enableHighAccuracy: Boolean,
         onLocationGranted: suspend () -> Unit
     ) {
         permissionsFlow = MutableSharedFlow(replay = 1)
 
         // first, we request permissions if necessary
-        val permissions = getDeclaredPermissions()
+        val permissions = getDeclaredPermissions(enableHighAccuracy)
         if (permissions.isEmpty()) {
             callbackContext.sendError(OSGeolocationErrors.LOCATION_MANIFEST_PERMISSIONS_MISSING)
             return
@@ -337,9 +338,11 @@ class OSGeolocation : CordovaPlugin() {
     /**
      * Get the location permissions to request based on the ones declared in app's manifest.
      *
+     * @param enableHighAccuracy true if meant to do a high accuracy location request, false otherwise
+     *
      * @return the array of declared location permissions, expected size 0-2
      */
-    private fun getDeclaredPermissions(): Array<String> {
+    private fun getDeclaredPermissions(enableHighAccuracy: Boolean): Array<String> {
         val permissionList = mutableListOf<String>()
         try {
             val packageManager = cordova.activity.packageManager
@@ -364,7 +367,16 @@ class OSGeolocation : CordovaPlugin() {
         } catch (e: Exception) {
             Log.d(LOG_TAG, e.message.toString())
         }
-        return permissionList.toSet().toTypedArray()
+        val permissionSet = permissionList.toMutableSet()
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+            // below Android 12 there is no distinction between FINE and COARSE
+            permissionSet.add(Manifest.permission.ACCESS_FINE_LOCATION)
+        } else if (!enableHighAccuracy) {
+            // on Android >= 12, ACCESS_FINE_LOCATION should only be required for PRIORTY_HIGH_ACCURACY
+            //  if the caller does not request high accuracy, then ACCESS_FINE_LOCATION isn't required
+            permissionSet.remove(Manifest.permission.ACCESS_FINE_LOCATION)
+        }
+        return permissionSet.toTypedArray()
     }
 
     /**

--- a/packages/cordova-plugin/android/OSGeolocation.kt
+++ b/packages/cordova-plugin/android/OSGeolocation.kt
@@ -73,12 +73,15 @@ class OSGeolocation : CordovaPlugin() {
             "getCurrentPosition" -> {
                 getCurrentPosition(args, callbackContext)
             }
+
             "watchPosition" -> {
                 watchPosition(args, callbackContext)
             }
+
             "clearWatch" -> {
                 clearWatch(args, callbackContext)
             }
+
             "hasNativeTimeoutHandling" -> {
                 hasNativeTimeoutHandling(callbackContext)
             }
@@ -109,7 +112,8 @@ class OSGeolocation : CordovaPlugin() {
                     enableLocationManagerFallback = options.optBoolean(ENABLE_FALLBACK, true)
                 )
 
-                val locationResult = controller.getCurrentPosition(cordova.activity, locationOptions)
+                val locationResult =
+                    controller.getCurrentPosition(cordova.activity, locationOptions)
 
                 if (locationResult.isSuccess) {
                     callbackContext.sendSuccess(JSONObject(gson.toJson(locationResult.getOrNull())))
@@ -247,7 +251,10 @@ class OSGeolocation : CordovaPlugin() {
      * @param result JSONObject with the JSON content to return, or null if there's no json data
      * @param keepCallback whether the callback should be kept or not. By default, false
      */
-    private fun CallbackContext.sendSuccess(result: JSONObject? = null, keepCallback: Boolean = false) {
+    private fun CallbackContext.sendSuccess(
+        result: JSONObject? = null,
+        keepCallback: Boolean = false
+    ) {
         val pluginResult = if (result != null) {
             PluginResult(PluginResult.Status.OK, result)
         } else {
@@ -277,7 +284,10 @@ class OSGeolocation : CordovaPlugin() {
      * @param callbackContext CallbackContext to use in case an error should be returned
      * @param onLocationGranted callback to use in case permissions are granted
      */
-    private suspend fun handleLocationPermission(callbackContext: CallbackContext, onLocationGranted: suspend () -> Unit) {
+    private suspend fun handleLocationPermission(
+        callbackContext: CallbackContext,
+        onLocationGranted: suspend () -> Unit
+    ) {
         permissionsFlow = MutableSharedFlow(replay = 1)
 
         // first, we request permissions if necessary

--- a/packages/cordova-plugin/android/OSGeolocation.kt
+++ b/packages/cordova-plugin/android/OSGeolocation.kt
@@ -96,7 +96,7 @@ class OSGeolocation : CordovaPlugin() {
         val options: JSONObject
         try {
             options = args.getJSONObject(0)
-        } catch (e: Exception) {
+        } catch (_: Exception) {
             callbackContext.sendError(OSGeolocationErrors.INVALID_INPUT_GET_POSITION)
             return
         }
@@ -131,7 +131,7 @@ class OSGeolocation : CordovaPlugin() {
         val options: JSONObject
         try {
             options = args.getJSONObject(0)
-        } catch (e: Exception) {
+        } catch (_: Exception) {
             callbackContext.sendError(OSGeolocationErrors.INVALID_INPUT_WATCH_POSITION)
             return
         }
@@ -217,7 +217,7 @@ class OSGeolocation : CordovaPlugin() {
         val options: JSONObject
         try {
             options = args.getJSONObject(0)
-        } catch (e: Exception) {
+        } catch (_: Exception) {
             callbackContext.sendError(OSGeolocationErrors.INVALID_INPUT_CLEAR_WATCH)
             return
         }
@@ -246,7 +246,7 @@ class OSGeolocation : CordovaPlugin() {
 
     /**
      * Extension function to return a successful plugin result
-     * @param result JSONObject with the JSON content to return, or null if there's no json data
+     * @param result JSONObject with the JSON content to return, or null if there's no JSON data
      * @param keepCallback whether the callback should be kept or not. By default, false
      */
     private fun CallbackContext.sendSuccess(
@@ -263,7 +263,7 @@ class OSGeolocation : CordovaPlugin() {
     }
 
     /**
-     * Extension function to return a unsuccessful plugin result
+     * Extension function to return an unsuccessful plugin result
      * @param error error class representing the error to return, containing a code and message
      */
     private fun CallbackContext.sendError(error: OSGeolocationErrors.ErrorInfo) {
@@ -372,8 +372,9 @@ class OSGeolocation : CordovaPlugin() {
      * Because cordova-android had a bug where onRequestPermissionsResult was not called
      * Fixed in https://github.com/apache/cordova-android/pull/1855
      * But existing MABS versions do not have that PR yet in the cordova-android fork
-     * https://github.com/OutSystems/cordova-android;
-     * so we'll have to wait for that until we can change to onRequestPermissionsResult here.
+     * https://github.com/OutSystems/cordova-android
+     * (particularly outsystems/14.0.x and outsystems/13.0.x branches)
+     * so we'll have to wait until we can change to onRequestPermissionsResult here.
      */
     override fun onRequestPermissionResult(
         requestCode: Int,

--- a/packages/cordova-plugin/android/OSGeolocationErrors.kt
+++ b/packages/cordova-plugin/android/OSGeolocationErrors.kt
@@ -83,4 +83,9 @@ object OSGeolocationErrors {
         code = formatErrorCode(17),
         message = "Unable to retrieve location because device has both Network and Location turned off."
     )
+
+    val LOCATION_MANIFEST_PERMISSIONS_MISSING = ErrorInfo(
+        code = formatErrorCode(18),
+        message = "Location permissions are not declared in manifest. Make sure at least ACCESS_COARSE_LOCATION is declared in AndroidManifest.xml, and optionally ACCESS_FINE_LOCATION if you require precise location access."
+    )
 }

--- a/packages/cordova-plugin/android/OSGeolocationErrors.kt
+++ b/packages/cordova-plugin/android/OSGeolocationErrors.kt
@@ -38,7 +38,7 @@ object OSGeolocationErrors {
         code = formatErrorCode(6),
         message = "The 'ClearWatch' input parameters aren't valid."
     )
-    
+
     val LOCATION_ENABLE_REQUEST_DENIED = ErrorInfo(
         code = formatErrorCode(9),
         message = "Request to enable location was denied."

--- a/plugin.xml
+++ b/plugin.xml
@@ -17,11 +17,10 @@
             <preference name="GradlePluginKotlinCodeStyle" value="official" />
             <preference name="AndroidXEnabled" value="true"/>
         </config-file>
-        
-        <config-file target="AndroidManifest.xml" parent="/*">
-            <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-            <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-        </config-file>
+
+        <!-- LOCATION_PERMISSION_TYPE: PRECISE (default), APPROXIMATE, or NONE -->
+        <preference name="LOCATION_PERMISSION_TYPE" default="PRECISE" />
+        <hook type="after_prepare" src="hooks/androidLocationPermissions.js" />
 
         <source-file src="packages/cordova-plugin/android/OSGeolocation.kt" target-dir="app/src/main/kotlin/com/outsystems/plugins/geolocation" />
         <source-file src="packages/cordova-plugin/android/OSGeolocationPermissionEvents.kt" target-dir="app/src/main/kotlin/com/outsystems/plugins/geolocation" />


### PR DESCRIPTION
# ⚠️ Mix of AI-generated content with manual changes and verification

## Description

This PR allows to not include `ACCESS_FINE_LOCATION` in the app's Android Manifest, instead of always including it.

The way this is done is via a cordova Hook for Cordova OutSystems Apps and build action (generated using the `build-actions-generator` AI skill + a few iterations) for Capacitor OutSystems Apps. Users can customize which permissions to include via the new `LOCATION_PERMISSION_TYPE` preference / variable, which by default is `PRECISE` to include `ACCESS_FINE_LOCATION` (and COARSE). This default value is to preserve backwards-compatibility with older plugin versions.

> ℹ️  **Note no.1:** There is a `APPROXIMATE` to only include `ACCESS_COARSE_LOCATION`, and a `NONE` which does not include any of the permissions. This one might not be relevant for the Plugin, but I added it in preparation for the Location Button feature for Android 17 (at time of writing 15 Jun 2026 still no available developer docs on how to use it). If we find that it's not needed, we can remove it

> ℹ️  **Note no.2:** The build action first has to always add the permissions, then remove them depending on the value for `LOCATION_PERMISSION_TYPE`.  This is because we can't stack conditions with AND's, such is not supported for build actions. This is why the hook conditionally adds, and the build action conditionally removes. We could also make the hook conditionally remove, but I don't think it's that much of a big deal, since this applies for OutSystems builds (i.e. the hook and build action only run once).

Furthermore, the plugin's source code requires changes to handle the fact that permissions may not be included in the manifest:

1. If there’s only `ACCESS_COARSE_LOCATION` in manifest, `ACCESS_FINE_LOCATION` is not requested.
2. If there's no location permissions defined in the manifest, return a newly created `OS-PLUG-GLOC-0018` error.
3. Request `ACCESS_FINE_LOCATION` only if it exists in the manifest, and if `enableHighAccuracy` is set to true, or if Android version is < 12 (when there is no COARSE / FINE distinction) - This aligns the behavior with the Capacitor Plugin.

Finally, there was a few cosmetic changes to the code + fixing some warnings reported by Android studio, but nothing that impacts the plugin.

## Context

[Google Play Permission policy updates](https://support.google.com/googleplay/android-developer/answer/16909972#location-permissions) are tightening the declaration of `ACCESS_FINE_LOCATION` in android apps for Android 17. Prior to this PR, there was no way to not have `ACCESS_FINE_LOCATION` for apps using the OutSystems Location Plugin.

Internal JIRA Ref: https://outsystemsrd.atlassian.net/browse/RMET-5198

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests

I've tested with a multitude of combinations of the PREFERENCE / MABS versions / Android versions to check that location requests still work, the sample apk's are available [here in this drive link](https://drive.google.com/drive/folders/14lvigdxD51YM7dKpsMght42I1IpBfp-5?usp=sharing). You don't need to test them all, but feel free to pick up one or two apk's and test on different Android versions (specifically < 12, >= 12 and/or Android 17).

As for what to test, I loosely-followed this [AI-generated test plan](https://github.com/user-attachments/files/28955945/RMET-5198-test-plan.md), but if you've already tested the Location Plugin before, it's just checking that location is received.

> ⚠️ Note on Emulators: The Android < 12 emulators seem to missbehave when the `ACCESS_FINE_LOCATION` is not defined in the manifest, so I recommend in that case either test with a physical device for < 12, or if you don't have physical devices, use Sauce Labs / Firebase Test Lab or stick to just > 12 emulator.

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [ ] Code follows code style of this project
- [ ] Using [conventional commits](https://www.conventionalcommits.org/)
- [x] Changes require an update to the documentation
	- We need to update OutSystems documentation with information of this feature, but we will only do so in the context of another task (RMET 5199), not this one.
