### PR TITLE
fix(android): Return error when user rejects request to turn on location with `enableLocationManagerFallback=true`

### DIFF
--- a/packages/cordova-plugin/android/build.gradle
+++ b/packages/cordova-plugin/android/build.gradle
@@ -17,7 +17,7 @@ allprojects {
 }
 
 dependencies {
-    implementation("io.ionic.libs:iongeolocation-android:2.2.0")
+    implementation("io.ionic.libs:iongeolocation-android:2.2.1")
     implementation("androidx.browser:browser:1.8.0")
     implementation("com.google.android.gms:play-services-auth:21.2.0")
     implementation("com.google.android.gms:play-services-location:21.3.0")


### PR DESCRIPTION
Simple PR to update native library following https://github.com/ionic-team/ion-android-geolocation/pull/12

Not looking for reviews, merging as soon as CI passes.