### PR TITLE
fix(ios): Correct error when location services are off

### DIFF
--- a/packages/cordova-plugin/ios/OSGeolocationPlugin.swift
+++ b/packages/cordova-plugin/ios/OSGeolocationPlugin.swift
@@ -110,7 +110,11 @@ private extension OSGeolocation {
 
                 switch status {
                 case .denied:
-                    self.callbackManager?.sendError(.permissionDenied)
+                    if self.locationService?.areLocationServicesEnabled() == false {
+                        self.callbackManager?.sendError(.locationServicesDisabled)
+                    } else {
+                        self.callbackManager?.sendError(.permissionDenied)
+                    }
                 case .notDetermined:
                     self.requestLocationAuthorisation(type: .whenInUse)
                 case .restricted:
@@ -201,7 +205,12 @@ private extension OSGeolocation {
 
         switch locationService?.authorisationStatus {
         case .authorisedAlways, .authorisedWhenInUse: requestLocation()
-        case .denied: callbackManager?.sendError(.permissionDenied)
+        case .denied:
+            if locationService?.areLocationServicesEnabled() == false {
+                callbackManager?.sendError(.locationServicesDisabled)
+            } else {
+                callbackManager?.sendError(.permissionDenied)
+            }
         case .restricted: callbackManager?.sendError(.permissionRestricted)
         default: break
         }


### PR DESCRIPTION
While testing https://github.com/ionic-team/cordova-outsystems-geolocation/pull/26 on iOS, I noticed that `getCurrentPosition` and `addWatch`, when location services are off, `permissionDenied` was always being returned, even if permission was granted previously. When location services are off, the `authorisationStatus` is always returned as `denied`.

This PR fixes it. Keep in mind `areLocationServicesEnabled` can be called regardless of location permission being granted or not.